### PR TITLE
Fix button text color bug

### DIFF
--- a/style.css
+++ b/style.css
@@ -256,11 +256,11 @@
         }
 
         .button span {
-            color: #6c757d;
+            color: inherit;
         }
 
         .button svg {
-            color: #6c757d;
+            color: inherit;
         }
 
         .button:hover {


### PR DESCRIPTION
## Summary
- ensure button text uses inherited color so the text is visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6859586e3a0c832f8c26bb105387bcaf