### PR TITLE
Fix button text color bug

### DIFF
--- a/style.css
+++ b/style.css
@@ -256,11 +256,11 @@
         }
 
         .button span {
-            color: #6c757d;
+            color: inherit;
         }
 
         .button svg {
-            color: #6c757d;
+            color: inherit;
         }
 
         .button:hover {
@@ -381,7 +381,7 @@
 
         .state p span {
             display: block;
-            opacity: 0;
+            opacity: 1;
             animation: slideDown 0.8s ease forwards calc(var(--i) * 0.03s);
         }
 


### PR DESCRIPTION
## Summary
- ensure button text uses inherited color so the text is visible
- make button letters fully opaque by default

## Testing
- `npm test` *(fails: could not find package.json)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6859586e3a0c832f8c26bb105387bcaf